### PR TITLE
Track delivery state for bolus and temp basal

### DIFF
--- a/pkg/command/programinsulin.go
+++ b/pkg/command/programinsulin.go
@@ -10,6 +10,7 @@ type ProgramInsulin struct {
 	ID       []byte
 	TableNum byte
 	Pulses   uint16
+	Duration uint8 // Number of half hour increments
 }
 
 func UnmarshalProgramInsulin(data []byte) (*ProgramInsulin, error) {
@@ -20,6 +21,7 @@ func UnmarshalProgramInsulin(data []byte) (*ProgramInsulin, error) {
 	// 1a LL NNNNNNNN 02 CCCC HH SSSS PPPP 0ppp
 	//    00 01020304 05 0607 08 0910 1112 1314
 	ret.TableNum = data[5]
+	ret.Duration = data[8]
 	ret.Pulses = (uint16(data[11]) << 8) + uint16(data[12])
 	return ret, nil
 }

--- a/pkg/pod/state.go
+++ b/pkg/pod/state.go
@@ -19,7 +19,7 @@ type PODState struct {
 	MsgSeq         uint8  `toml:"msg_seq"`   // TODO: is this the same as nonceSeq?
 	CmdSeq         uint8  `toml:"cmd_seq"`   // TODO: are all those 3 the same number ???
 	NonceSeq       uint64 `toml:"nonce_seq"` // or 16?
-	
+
 	LastProgSeqNum uint8  `toml:"last_prog_seq"`
 
 	NoncePrefix []byte `toml:"nonce_prefix"`
@@ -36,10 +36,10 @@ type PODState struct {
 
 	// At some point these could be replaced with details
 	// of each kind of delivery (volume, start time, schedule, etc)
-	BolusActive         bool `toml:"bolus_active"`
-	BasalActive         bool `toml:"basal_active"`
-	TempBasalActive     bool `toml:"temp_basal_active"`
-	ExtendedBolusActive bool `toml:"extended_bolus_active"`
+	BolusEnd            time.Time `toml:"bolus_end"`
+	TempBasalEnd        time.Time `toml:"temp_basal_end"`
+	ExtendedBolusActive bool      `toml:"extended_bolus_active"`
+	BasalActive         bool      `toml:"basal_active"`
 
 	Filename string
 }


### PR DESCRIPTION
Pod simulator with these changes should return correct flags for bolusing or temp basal delivery states for the programmed duration.