### PR TITLE
Detailed and general response fixes and improvements

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -341,16 +341,14 @@ func (p *Pod) makeGeneralStatusResponse() response.Response {
 	log.Debugf("pkg pod; General status response LastProgSeqNum = %d", p.state.LastProgSeqNum)
 
 	var now = time.Now()
-	var tempBasalActive = p.state.TempBasalEnd.After(now)
 
 	return &response.GeneralStatusResponse{
-		Seq:                 0,
 		LastProgSeqNum:      p.state.LastProgSeqNum,
 		Reservoir:           p.state.Reservoir,
 		Alerts:              p.state.ActiveAlertSlots,
 		BolusActive:         p.state.BolusEnd.After(now),
-		TempBasalActive:     tempBasalActive,
-		BasalActive:         p.state.BasalActive && !tempBasalActive,
+		TempBasalActive:     p.state.TempBasalEnd.After(now),
+		BasalActive:         p.state.BasalActive,
 		ExtendedBolusActive: p.state.ExtendedBolusActive,
 		PodProgress:         p.state.PodProgress,
 		Delivered:           p.state.Delivered,
@@ -362,19 +360,18 @@ func (p *Pod) makeGeneralStatusResponse() response.Response {
 func (p *Pod) makeDetailedStatusResponse() response.Response {
 
 	var now = time.Now()
-	var tempBasalActive = p.state.TempBasalEnd.After(now)
 
 	return &response.DetailedStatusResponse{
-		Seq:                 0,
 		LastProgSeqNum:      p.state.LastProgSeqNum,
 		Reservoir:           p.state.Reservoir,
 		Alerts:              p.state.ActiveAlertSlots,
 		BolusActive:         p.state.BolusEnd.After(now),
-		TempBasalActive:     tempBasalActive,
-		BasalActive:         p.state.BasalActive && !tempBasalActive,
+		TempBasalActive:     p.state.TempBasalEnd.After(now),
+		BasalActive:         p.state.BasalActive,
 		ExtendedBolusActive: p.state.ExtendedBolusActive,
 		PodProgress:         p.state.PodProgress,
 		Delivered:           p.state.Delivered,
+		BolusRemaining:      p.state.BolusRemaining(),
 		MinutesActive:       p.state.MinutesActive(),
 		FaultEvent:          p.state.FaultEvent,
 		FaultEventTime:      p.state.FaultTime,

--- a/pkg/response/generalstatusresponse.go
+++ b/pkg/response/generalstatusresponse.go
@@ -43,7 +43,6 @@ const (
 )
 
 type GeneralStatusResponse struct {
-	Seq                 uint16
 	Alerts              uint8
 	BolusActive         bool
 	TempBasalActive     bool
@@ -61,23 +60,22 @@ type GeneralStatusResponse struct {
 func (r *GeneralStatusResponse) Marshal() ([]byte, error) {
 	response, _ := hex.DecodeString("1D1800A02800000463FF") // Default
 
-	// Delivery bits
-	response[1] = response[1] & 0b1111
+	// PodProgress returned in low nibble
+	response[1] = byte(r.PodProgress) & 0b1111
+
+	// Delivery bits returned in upper nibble
 	if r.ExtendedBolusActive {
-		response[1] = response[1] | (1 << 7)
-	}
-	if r.BolusActive {
-		response[1] = response[1] | (1 << 6)
+		// extended bolus bit exclusive of bolus active bit
+		response[1] |= 0b100 << 4
+	} else if r.BolusActive {
+		response[1] |= 0b010 << 4
 	}
 	if r.TempBasalActive {
-		response[1] = response[1] | (1 << 5)
+		// temp basal active bit exclusive of basal active bit
+		response[1] |= 0b0010 << 4
+	} else if r.BasalActive {
+		response[1] |= 0b0001 << 4
 	}
-	if r.BasalActive {
-		response[1] = response[1] | (1 << 4)
-	}
-
-	// PodProgress
-	response[1] = response[1]&0b11110000 | (byte(r.PodProgress) & 0b1111)
 
 	// Total insulin delivered
 	response[2] = byte(r.Delivered >> 9)
@@ -99,7 +97,7 @@ func (r *GeneralStatusResponse) Marshal() ([]byte, error) {
 	response[7] = response[7]&0b10000000 | uint8((r.MinutesActive>>6)&0b01111111)
 	response[8] = response[8]&0b00000011 | uint8((r.MinutesActive<<2)&0b11111100)
 
-	if r.Reservoir < (50 / 0.05) {
+	if r.Reservoir <= (50 / 0.05) {
 		response[8] = response[8]&0b11111100 | uint8(r.Reservoir>>8)
 		response[9] = uint8(r.Reservoir & 0xff)
 	} else {

--- a/pkg/response/generalstatusresponse.go
+++ b/pkg/response/generalstatusresponse.go
@@ -66,9 +66,9 @@ func (r *GeneralStatusResponse) Marshal() ([]byte, error) {
 	// Delivery bits returned in upper nibble
 	if r.ExtendedBolusActive {
 		// extended bolus bit exclusive of bolus active bit
-		response[1] |= 0b100 << 4
+		response[1] |= 0b1000 << 4
 	} else if r.BolusActive {
-		response[1] |= 0b010 << 4
+		response[1] |= 0b0100 << 4
 	}
 	if r.TempBasalActive {
 		// temp basal active bit exclusive of basal active bit


### PR DESCRIPTION
+ Use a Dash style DetailedStatus instead of Eros style
+ Use the correct byte for DetailedStatus Alerts
+ Fix reservoir level boundary handling for both responses
+ Improved DetailedStatus pod fault & progress handling
+ Improved delivery bit handling for both response types
+ Remove unused Seq member from both response types