### PR TITLE
Modify reconnect rate to 3 minutes

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -214,7 +214,7 @@ func (p *Pod) CommandLoop(pMsg PodMsgBody) {
 			log.Exit(0)
 		}
 		log.Infof("pkg pod;   *** Waiting for the next command ***")
-		msg, didTimeout := p.ble.ReadMessageWithTimeout(1 * time.Minute)
+		msg, didTimeout := p.ble.ReadMessageWithTimeout(3 * time.Minute)
 		if didTimeout {
 			p.ble.ShutdownConnection()
 			go func() {


### PR DESCRIPTION
Tested on rPi.
This modification changes the update rate to 3-minutes to match that for TWI DASH pods.