### PR TITLE
return suspend when pod fault is detected

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -471,6 +471,14 @@ func (p *Pod) handleCommand(cmd command.Command) {
 		}
 	}
 
+	if p.state.PodProgress == response.PodProgressRunningAbove50U {
+		// transition PodProgress when reservoir is below 50 / 0.05 = 1000 pulses
+		if p.state.Reservoir <= 1000 {
+			log.Infof("*** Advancing progress to PodProgressRunningBelow50U based on reservoir value")
+			p.state.PodProgress = response.PodProgressRunningBelow50U
+		}
+	}
+
 	if crashBeforeProcessingCommand && cmd.DoesMutatePodState() {
 		log.Fatalf("pkg pod; Crashing before processing command with sequence %d", cmd.GetSeq())
 	}

--- a/pkg/response/detailedstatusresponse.go
+++ b/pkg/response/detailedstatusresponse.go
@@ -31,23 +31,25 @@ func (r *DetailedStatusResponse) Marshal() ([]byte, error) {
 	// PodProgress
 	if r.FaultEvent == 0 {
 		response[3] = byte(r.PodProgress)
+
+		// Delivery bits
+		response[4] = 0 // suspended
+		if r.ExtendedBolusActive {
+			// extended bolus bit exclusive of bolus active bit
+			response[4] |= 0b1000
+		} else if r.BolusActive {
+			response[4] |= 0b0100
+		}
+		if r.TempBasalActive {
+			// temp basal active bit exclusive of basal active bit
+			response[4] |= 0b0010
+		} else if r.BasalActive {
+			response[4] |= 0b0001
+		}
+
 	} else {
 		response[3] = PodProgressFault
-	}
-
-	// Delivery bits
-	response[4] = 0 // suspended
-	if r.ExtendedBolusActive {
-		// extended bolus bit exclusive of bolus active bit
-		response[4] |= 0b1000
-	} else if r.BolusActive {
-		response[4] |= 0b0100
-	}
-	if r.TempBasalActive {
-		// temp basal active bit exclusive of basal active bit
-		response[4] |= 0b0010
-	} else if r.BasalActive {
-		response[4] |= 0b0001
+		response[4] = 0  // suspended
 	}
 
 	// Bolus remaining pulses


### PR DESCRIPTION
## Purpose

Make the rPi DASH simulator more realistic.
* Noticed that the response of the simulator to a fault does not set all delivery to false
* While testing, noticed another pod characteristic not reproduced in the simulator and updated that too
   * Transition the PodProgress to 9 when reservoir is <= 50 U

## Method

* Fix the logic to set response byte 4 to 0 in `pkg/response/detailedstatusresponse.go` when fault is detected.
* Reorganized `pkg/response/detailedstatusresponse.go` for clarity
* Updated `pkg/pod/pod.go` PodProgress value based on Reservoir value

## Test

Before this modification, whatever delivery state the rPi was in was left unchanged when pod fault was detected.
With this modification, the delivery state is suspended:
```
  pod_progress =	13
  extended_bolus_active =	False
  immediate_bolus_active =	False
  temp_basal_active =	False
  basal_active =	False
```

The Loop app properly indicates the pod as suspended at the time the pod fault is detected (although this does not show up in the Event History until after the pod is deactivated).
